### PR TITLE
Java debugger fixes

### DIFF
--- a/Tvl.Java.DebugHost/Interop/AgentExports.cs
+++ b/Tvl.Java.DebugHost/Interop/AgentExports.cs
@@ -227,7 +227,7 @@
         private static void HandleFirstChanceException(object sender, FirstChanceExceptionEventArgs e)
         {
             string caption = "First Chance Exception";
-            MessageBox.Show(e.Exception.Message + Environment.NewLine + Environment.NewLine + e.Exception.StackTrace, caption, MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
+            MessageBox.Show(e.Exception.Message + Environment.NewLine + Environment.NewLine + e.Exception.StackTrace + (new System.Diagnostics.StackTrace(1)), caption, MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
         }
 
         private static void HandleUnhandledException(object sender, UnhandledExceptionEventArgs e)

--- a/Tvl.Java.DebugHost/Services/DebugProtocolService.EventFilter.cs
+++ b/Tvl.Java.DebugHost/Services/DebugProtocolService.EventFilter.cs
@@ -343,8 +343,13 @@
                                 string methodGenericSignature;
                                 JvmtiErrorHandler.ThrowOnFailure(environment.GetMethodName(_lastMethod, out methodName, out methodSignature, out methodGenericSignature));
 
+                                jobject classLoader;
+                                JvmtiErrorHandler.ThrowOnFailure(environment.GetClassLoader(classHandle.Value, out classLoader));
+                                long classLoaderTag;
+                                JvmtiErrorHandler.ThrowOnFailure(environment.TagClassLoader(classLoader, out classLoaderTag));
+
                                 ReadOnlyCollection<ExceptionTableEntry> exceptionTable;
-                                JvmtiErrorHandler.ThrowOnFailure(environment.VirtualMachine.GetExceptionTable(classSignature, methodName, methodSignature, out exceptionTable));
+                                JvmtiErrorHandler.ThrowOnFailure(environment.VirtualMachine.GetExceptionTable(classLoaderTag, classSignature, methodName, methodSignature, out exceptionTable));
 
                                 _evaluationStackDepths = BytecodeDisassembler.GetEvaluationStackDepths(_disassembledMethod, _constantPool, exceptionTable);
                             }

--- a/Tvl.Java.DebugHost/Services/DebugProtocolService.EventProcessor.cs
+++ b/Tvl.Java.DebugHost/Services/DebugProtocolService.EventProcessor.cs
@@ -693,6 +693,9 @@
                 if (classSignature[0] != '[')
                     classSignature = 'L' + classSignature + ';';
 
+                long classLoaderTag;
+                JvmtiErrorHandler.ThrowOnFailure(Environment.TagClassLoader(loaderHandle, out classLoaderTag));
+
                 foreach (var methodInfo in classFile.Methods)
                 {
                     if ((methodInfo.Modifiers & (AccessModifiers.Abstract | AccessModifiers.Native)) != 0)
@@ -708,7 +711,7 @@
                     ConstantUtf8 constantMethodSignature = (ConstantUtf8)classFile.ConstantPool[methodInfo.DescriptorIndex - 1];
                     string methodSignature = constantMethodSignature.Value;
 
-                    VirtualMachine.SetExceptionTable(classSignature, methodName, methodSignature, codeAttribute.ExceptionTable);
+                    VirtualMachine.SetExceptionTable(classLoaderTag, classSignature, methodName, methodSignature, codeAttribute.ExceptionTable);
                 }
 
 #if false

--- a/Tvl.Java.DebugHost/Services/DebugProtocolService.cs
+++ b/Tvl.Java.DebugHost/Services/DebugProtocolService.cs
@@ -940,8 +940,18 @@
                 if (error != jvmtiError.None)
                     return GetStandardError(error);
 
+                jobject classLoader;
+                error = environment.GetClassLoader(classHandle.Value, out classLoader);
+                if (error != jvmtiError.None)
+                    return GetStandardError(error);
+
+                long classLoaderTag;
+                error = environment.TagClassLoader(classLoader, out classLoaderTag);
+                if (error != jvmtiError.None)
+                    return GetStandardError(error);
+
                 ReadOnlyCollection<ExceptionTableEntry> exceptionTable;
-                error = environment.VirtualMachine.GetExceptionTable(classSignature, methodName, methodSignature, out exceptionTable);
+                error = environment.VirtualMachine.GetExceptionTable(classLoaderTag, classSignature, methodName, methodSignature, out exceptionTable);
                 if (error != jvmtiError.None)
                     return GetStandardError(error);
 

--- a/Tvl.Java.DebugInterface.Client/ReferenceType.cs
+++ b/Tvl.Java.DebugInterface.Client/ReferenceType.cs
@@ -434,9 +434,11 @@
             if (_taggedTypeId.TypeTag == TypeTag.Class || _taggedTypeId.TypeTag == TypeTag.Interface)
             {
                 string signature = GetSignature().Substring(1);
-                string relativeFolder = signature.Substring(0, signature.LastIndexOf('/')).Replace('/', Path.DirectorySeparatorChar);
+                string relativeFolder = null;
+                if (signature.IndexOf('/') >= 0)
+                    relativeFolder = signature.Substring(0, signature.LastIndexOf('/')).Replace('/', Path.DirectorySeparatorChar);
 
-                List<string> paths = new List<string>(GetSourceNames(stratum).Select(i => Path.Combine(relativeFolder, i)));
+                List<string> paths = new List<string>(GetSourceNames(stratum).Select(i => string.IsNullOrEmpty(relativeFolder) ? i : Path.Combine(relativeFolder, i)));
                 for (int i = paths.Count - 1; i >= 0; i--)
                 {
                     string path = paths[i];

--- a/Tvl.Java.DebugInterface.Types/Loader/AttributeInfo.cs
+++ b/Tvl.Java.DebugInterface.Types/Loader/AttributeInfo.cs
@@ -37,7 +37,7 @@
             ushort attributeNameIndex = ConstantPoolEntry.ByteSwap((ushort)Marshal.ReadInt16(ptr, offset));
             uint attributeLength = ConstantPoolEntry.ByteSwap((uint)Marshal.ReadInt32(ptr, offset + sizeof(ushort)));
             byte[] info = new byte[attributeLength];
-            Marshal.Copy(ptr + offset, info, 0, (int)attributeLength);
+            Marshal.Copy(ptr + offset + sizeof(ushort) + sizeof(uint), info, 0, (int)attributeLength);
 
             ConstantUtf8 entry = (ConstantUtf8)constantPool[attributeNameIndex - 1];
             switch (entry.Value)

--- a/Tvl.Java.DebugInterface.Types/Loader/Code.cs
+++ b/Tvl.Java.DebugInterface.Types/Loader/Code.cs
@@ -14,7 +14,7 @@
         public Code(ushort attributeNameIndex, byte[] info)
             : base(attributeNameIndex, info)
         {
-            int offset = sizeof(ushort) + sizeof(uint);
+            int offset = 0;
             _maxStack = ConstantPoolEntry.ByteSwap(BitConverter.ToUInt16(info, offset));
             offset += 2;
 

--- a/Tvl.VisualStudio.Language.Java/Debugger/JavaDebugProgram.cs
+++ b/Tvl.VisualStudio.Language.Java/Debugger/JavaDebugProgram.cs
@@ -1085,8 +1085,15 @@
                 this._threads.TryGetValue(e.Thread.GetUniqueId(), out thread);
             }
 
-            ReadOnlyCollection<string> sourceFiles = e.Type.GetSourcePaths(e.Type.GetDefaultStratum());
-            DebugEngine.BindVirtualizedBreakpoints(this, thread, e.Type, sourceFiles);
+            try
+            {
+                ReadOnlyCollection<string> sourceFiles = e.Type.GetSourcePaths(e.Type.GetDefaultStratum());
+                DebugEngine.BindVirtualizedBreakpoints(this, thread, e.Type, sourceFiles);
+            }
+            catch (MissingInformationException)
+            {
+                // Can't bind debug information for classes that don't contain debug information
+            }
 
             // The format of the message created by the .NET debugger is this:
             // 'devenv.exe' (Managed (v4.0.30319)): Loaded 'C:\Windows\Microsoft.Net\assembly\GAC_MSIL\Microsoft.VisualStudio.Windows.Forms\v4.0_10.0.0.0__b03f5f7f11d50a3a\Microsoft.VisualStudio.Windows.Forms.dll'


### PR DESCRIPTION
* Show full stack traces when `ShowAgentExceptions` is enabled
* Fix handling for classes not in a package
* Fix handling for classes without debug information
* Fix deserialization of exception tables in Code attributes
* Fix tracking of exception tables across multiple class loaders (different versions of the same type can be loaded in the same process using different class loaders)