### PR TITLE
Java debugger cleanup

### DIFF
--- a/Tvl.Java.DebugHost/Interop/jvmtiCapabilities.cs
+++ b/Tvl.Java.DebugHost/Interop/jvmtiCapabilities.cs
@@ -353,6 +353,7 @@ namespace Tvl.Java.DebugHost.Interop
         [Flags]
         public enum CapabilityFlags1 : uint
         {
+            None = 0,
             CanTagObjects = 0x00000001,
             CanGenerateFieldModificationEvents = 0x00000002,
             CanGenerateFieldAccessEvents = 0x00000004,
@@ -390,6 +391,7 @@ namespace Tvl.Java.DebugHost.Interop
         [Flags]
         public enum CapabilityFlags2 : uint
         {
+            None = 0,
             CanGenerateObjectFreeEvents = 0x00000001,
             CanForceEarlyReturn = 0x00000002,
             CanGetOwnedMonitorStackDepthInfo = 0x00000004,
@@ -404,11 +406,13 @@ namespace Tvl.Java.DebugHost.Interop
         [Flags]
         public enum CapabilityFlags3 : uint
         {
+            None = 0,
         }
 
         [Flags]
         public enum CapabilityFlags4 : uint
         {
+            None = 0,
         }
     }
 }

--- a/Tvl.Java.DebugInterface.Types/Loader/ClassFile.cs
+++ b/Tvl.Java.DebugInterface.Types/Loader/ClassFile.cs
@@ -14,7 +14,7 @@
         private ushort _accessFlags;
         private ushort _thisClass;
         private ushort _superClass;
-        private short[] _interfaces;
+        private ushort[] _interfaces;
         private FieldInfo[] _fields;
         private MethodInfo[] _methods;
         private AttributeInfo[] _attributes;
@@ -118,9 +118,12 @@
             ushort interfacesCount = ConstantPoolEntry.ByteSwap((ushort)Marshal.ReadInt16(ptr, offset));
             offset += sizeof(ushort);
 
-            classFile._interfaces = new short[interfacesCount];
-            Marshal.Copy(ptr + offset, classFile._interfaces, 0, interfacesCount);
-            offset += interfacesCount * sizeof(ushort);
+            classFile._interfaces = new ushort[interfacesCount];
+            for (int i = 0; i < interfacesCount; i++)
+            {
+                classFile._interfaces[i] = ConstantPoolEntry.ByteSwap((ushort)Marshal.ReadInt16(ptr, offset));
+                offset += sizeof(ushort);
+            }
 
             ushort fieldsCount = ConstantPoolEntry.ByteSwap((ushort)Marshal.ReadInt16(ptr, offset));
             offset += sizeof(ushort);


### PR DESCRIPTION
* Fix deserialization of interfaces table (not currently used, but was still not correct)
* Added `None` enum members for flags enumerations