### PR TITLE
Fix ANTLR 3 code completion not working

### DIFF
--- a/Tvl.VisualStudio.Language.Alloy/AlloyLanguagePackage.cs
+++ b/Tvl.VisualStudio.Language.Alloy/AlloyLanguagePackage.cs
@@ -26,6 +26,10 @@
         EnableLineNumbers = true,
         //CodeSense = true,
         RequestStockColors = true)]
+    [ProvideLanguageCodeExpansion(typeof(AlloyLanguageInfo), AlloyConstants.AlloyLanguageName, AlloyConstants.AlloyLanguageResourceId, AlloyConstants.AlloyLanguageName, @"%InstallRoot%\Alloy\Snippets\1033\SnippetsIndex.xml",
+        SearchPaths = @"%InstallRoot%\Alloy\Snippets\%LCID%\Alloy;%MyDocs%\Code Snippets\Alloy\My Code Snippets\",
+        ForceCreateDirs = @"%InstallRoot%\Alloy\Snippets\%LCID%\Alloy;%MyDocs%\Code Snippets\Alloy\My Code Snippets\",
+        ShowRoots = false)]
     [ProvideLanguageExtension(typeof(AlloyLanguageInfo), AlloyConstants.AlloyFileExtension)]
     public class AlloyLanguagePackage : Package
     {

--- a/Tvl.VisualStudio.Language.Alloy/Tvl.VisualStudio.Language.Alloy.csproj
+++ b/Tvl.VisualStudio.Language.Alloy/Tvl.VisualStudio.Language.Alloy.csproj
@@ -267,6 +267,10 @@
       <Private>False</Private>
       <HintPath>..\packages\VSSDK.CoreUtility.10.0.4\lib\net40\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Editor, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>..\packages\VSSDK.Editor.10.0.4\lib\net40\Microsoft.VisualStudio.Editor.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
       <HintPath>..\packages\VSSDK.Language.10.0.4\lib\net40\Microsoft.VisualStudio.Language.Intellisense.dll</HintPath>

--- a/Tvl.VisualStudio.Language.Alloy/packages.config
+++ b/Tvl.VisualStudio.Language.Alloy/packages.config
@@ -9,6 +9,8 @@
   <package id="VSSDK.CoreUtility" version="10.0.4" targetFramework="net40" />
   <package id="VSSDK.CoreUtility.10" version="10.0.4" targetFramework="net40" />
   <package id="VSSDK.DTE" version="7.0.4" targetFramework="net40" />
+  <package id="VSSDK.Editor" version="10.0.4" targetFramework="net40" />
+  <package id="VSSDK.Editor.10" version="10.0.4" targetFramework="net40" />
   <package id="VSSDK.IDE" version="7.0.4" targetFramework="net40" />
   <package id="VSSDK.IDE.10" version="10.0.4" targetFramework="net40" />
   <package id="VSSDK.IDE.8" version="8.0.4" targetFramework="net40" />

--- a/Tvl.VisualStudio.Language.Antlr3/AntlrLanguagePackage.cs
+++ b/Tvl.VisualStudio.Language.Antlr3/AntlrLanguagePackage.cs
@@ -48,6 +48,10 @@
 
         // this item is last since it's always true
         EnableLineNumbers = true)]
+    [ProvideLanguageCodeExpansion(typeof(AntlrLanguageInfo), AntlrConstants.AntlrLanguageName, AntlrConstants.AntlrLanguageResourceId, AntlrConstants.AntlrLanguageName, @"%InstallRoot%\ANTLR\Snippets\1033\SnippetsIndex.xml",
+        SearchPaths = @"%InstallRoot%\ANTLR\Snippets\%LCID%\ANTLR;%MyDocs%\Code Snippets\ANTLR\My Code Snippets\",
+        ForceCreateDirs = @"%InstallRoot%\ANTLR\Snippets\%LCID%\ANTLR;%MyDocs%\Code Snippets\ANTLR\My Code Snippets\",
+        ShowRoots = false)]
     [ProvideLanguageExtension(typeof(AntlrLanguageInfo), AntlrConstants.AntlrFileExtension)]
     [ProvideLanguageExtension(typeof(AntlrLanguageInfo), AntlrConstants.AntlrFileExtension2)]
 
@@ -97,6 +101,10 @@
 
         // this item is last since it's always true
         EnableLineNumbers = true)]
+    [ProvideLanguageCodeExpansion(typeof(Antlr4LanguageInfo), Antlr4Constants.AntlrLanguageName, Antlr4Constants.AntlrLanguageResourceId, Antlr4Constants.AntlrLanguageName, @"%InstallRoot%\ANTLR4\Snippets\1033\SnippetsIndex.xml",
+        SearchPaths = @"%InstallRoot%\ANTLR4\Snippets\%LCID%\ANTLR4;%MyDocs%\Code Snippets\ANTLR4\My Code Snippets\",
+        ForceCreateDirs = @"%InstallRoot%\ANTLR4\Snippets\%LCID%\ANTLR4;%MyDocs%\Code Snippets\ANTLR4\My Code Snippets\",
+        ShowRoots = false)]
     [ProvideLanguageExtension(typeof(Antlr4LanguageInfo), Antlr4Constants.AntlrFileExtension)]
 
     [ProvideDebuggerException(typeof(Antlr4.Runtime.FailedPredicateException))]

--- a/Tvl.VisualStudio.Language.Chapel/ChapelLanguagePackage.cs
+++ b/Tvl.VisualStudio.Language.Chapel/ChapelLanguagePackage.cs
@@ -26,6 +26,10 @@
         EnableLineNumbers = true,
         //CodeSense = true,
         RequestStockColors = true)]
+    [ProvideLanguageCodeExpansion(typeof(ChapelLanguageInfo), ChapelConstants.ChapelLanguageName, ChapelConstants.ChapelLanguageResourceId, ChapelConstants.ChapelLanguageName, @"%InstallRoot%\Chapel\Snippets\1033\SnippetsIndex.xml",
+        SearchPaths = @"%InstallRoot%\Chapel\Snippets\%LCID%\Chapel;%MyDocs%\Code Snippets\Chapel\My Code Snippets\",
+        ForceCreateDirs = @"%InstallRoot%\Chapel\Snippets\%LCID%\Chapel;%MyDocs%\Code Snippets\Chapel\My Code Snippets\",
+        ShowRoots = false)]
     [ProvideLanguageExtension(typeof(ChapelLanguageInfo), ChapelConstants.ChapelFileExtension)]
     public class ChapelLanguagePackage : Package
     {

--- a/Tvl.VisualStudio.Language.Go/GoLanguagePackage.cs
+++ b/Tvl.VisualStudio.Language.Go/GoLanguagePackage.cs
@@ -26,6 +26,10 @@
         EnableLineNumbers = true,
         //CodeSense = true,
         RequestStockColors = true)]
+    [ProvideLanguageCodeExpansion(typeof(GoLanguageInfo), GoConstants.GoLanguageName, GoConstants.GoLanguageResourceId, GoConstants.GoLanguageName, @"%InstallRoot%\Go\Snippets\1033\SnippetsIndex.xml",
+        SearchPaths = @"%InstallRoot%\Go\Snippets\%LCID%\Go;%MyDocs%\Code Snippets\Go\My Code Snippets\",
+        ForceCreateDirs = @"%InstallRoot%\Go\Snippets\%LCID%\Go;%MyDocs%\Code Snippets\Go\My Code Snippets\",
+        ShowRoots = false)]
     [ProvideLanguageExtension(typeof(GoLanguageInfo), GoConstants.GoFileExtension)]
     public class GoLanguagePackage : Package
     {

--- a/Tvl.VisualStudio.Language.Php/PhpLanguagePackage.cs
+++ b/Tvl.VisualStudio.Language.Php/PhpLanguagePackage.cs
@@ -28,6 +28,10 @@
         EnableLineNumbers = true,
         //CodeSense = true,
         RequestStockColors = true)]
+    [ProvideLanguageCodeExpansion(typeof(PhpLanguageInfo), PhpConstants.PhpLanguageName, PhpConstants.PhpLanguageResourceId, PhpConstants.PhpLanguageName, @"%InstallRoot%\PHP\Snippets\1033\SnippetsIndex.xml",
+        SearchPaths = @"%InstallRoot%\PHP\Snippets\%LCID%\PHP;%MyDocs%\Code Snippets\PHP\My Code Snippets\",
+        ForceCreateDirs = @"%InstallRoot%\PHP\Snippets\%LCID%\PHP;%MyDocs%\Code Snippets\PHP\My Code Snippets\",
+        ShowRoots = false)]
 
     [ProvideEditorFactory2(typeof(PhpEditorFactoryWithoutEncoding), 101, CommonPhysicalViewAttributes = (int)__VSPHYSICALVIEWATTRIBUTES.PVA_SupportsPreview)]
     [ProvideLinkedEditorFactory(typeof(PhpEditorFactoryWithEncoding), typeof(PhpEditorFactoryWithoutEncoding), 102, CommonPhysicalViewAttributes = (int)__VSPHYSICALVIEWATTRIBUTES.PVA_None)]

--- a/Tvl.VisualStudio.Language.StringTemplate4/StringTemplateLanguagePackage.cs
+++ b/Tvl.VisualStudio.Language.StringTemplate4/StringTemplateLanguagePackage.cs
@@ -26,6 +26,10 @@
         EnableLineNumbers = true,
         //CodeSense = true,
         RequestStockColors = true)]
+    [ProvideLanguageCodeExpansion(typeof(StringTemplateLanguageInfo), StringTemplateConstants.StringTemplateLanguageName, StringTemplateConstants.StringTemplateLanguageResourceId, StringTemplateConstants.StringTemplateLanguageName, @"%InstallRoot%\StringTemplate\Snippets\1033\SnippetsIndex.xml",
+        SearchPaths = @"%InstallRoot%\StringTemplate\Snippets\%LCID%\StringTemplate;%MyDocs%\Code Snippets\StringTemplate\My Code Snippets\",
+        ForceCreateDirs = @"%InstallRoot%\StringTemplate\Snippets\%LCID%\StringTemplate;%MyDocs%\Code Snippets\StringTemplate\My Code Snippets\",
+        ShowRoots = false)]
     [ProvideLanguageExtension(typeof(StringTemplateLanguageInfo), StringTemplateConstants.StringTemplateGroupFileExtension)]
     [ProvideLanguageExtension(typeof(StringTemplateLanguageInfo), StringTemplateConstants.StringTemplateGroup4FileExtension)]
     [ProvideLanguageExtension(typeof(StringTemplateLanguageInfo), StringTemplateConstants.StringTemplateTemplateFileExtension)]

--- a/Tvl.VisualStudio.Language/Intellisense/IntellisenseController.cs
+++ b/Tvl.VisualStudio.Language/Intellisense/IntellisenseController.cs
@@ -6,6 +6,7 @@
     using System.Diagnostics.Contracts;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Editor;
     using Microsoft.VisualStudio.Language.Intellisense;
     using Microsoft.VisualStudio.Text;
     using Microsoft.VisualStudio.Text.Editor;
@@ -17,7 +18,7 @@
     using VsMenus = Microsoft.VisualStudio.Shell.VsMenus;
     using VSOBJGOTOSRCTYPE = Microsoft.VisualStudio.Shell.Interop.VSOBJGOTOSRCTYPE;
 
-    public class IntellisenseController : ITvlIntellisenseController, IIntellisenseController
+    public class IntellisenseController : ITvlIntellisenseController, IIntellisenseController, IVsTextViewCreationListener
     {
         private readonly IntellisenseControllerProvider _provider;
 
@@ -476,9 +477,10 @@
             return false;
         }
 
-        public virtual void OnVsTextViewCreated(IVsTextView textViewAdapter)
+        public virtual void VsTextViewCreated(IVsTextView textViewAdapter)
         {
-            Contract.Requires<ArgumentNullException>(textViewAdapter != null, "textViewAdapter");
+            if (textViewAdapter == null)
+                throw new ArgumentNullException("textViewAdapter");
 
             _commandFilter = CreateIntellisenseCommandFilter(textViewAdapter);
             if (_commandFilter != null)

--- a/Tvl.VisualStudio.Shell/Extensions/IVsExpansionManagerExtensions.cs
+++ b/Tvl.VisualStudio.Shell/Extensions/IVsExpansionManagerExtensions.cs
@@ -24,8 +24,8 @@
             bool includeNullType = false;
             bool includeDuplicates = false;
 
-            IVsExpansionEnumeration expEnum;
-            if (ErrorHandler.Succeeded(expansionManager.EnumerateExpansions(language, shortcutsOnly ? 1 : 0, snippetTypes, snippetTypes.Length, includeNullType ? 1 : 0, includeDuplicates ? 1 : 0, out expEnum)))
+            IVsExpansionEnumeration expEnum = null;
+            if (ErrorHandler.Succeeded(ErrorHandler.CallWithCOMConvention(() => expansionManager.EnumerateExpansions(language, shortcutsOnly ? 1 : 0, snippetTypes, snippetTypes.Length, includeNullType ? 1 : 0, includeDuplicates ? 1 : 0, out expEnum))))
             {
                 uint count;
                 ErrorHandler.ThrowOnFailure(expEnum.GetCount(out count));


### PR DESCRIPTION
For some reason the IntelliSense controller was modified such that code completion for ANTLR 3 grammars no longer worked. After fixing this, I also found that support for code snippets in Visual Studio 2015 wasn't working properly, so I fixed its exception handling and also added a registration attribute so ANTLR snippets work in each language.