### PR TITLE
Remove references to legacy smart tag sessions

### DIFF
--- a/Tvl.VisualStudio.Language.Interfaces/Intellisense/ITvlIntellisenseController.cs
+++ b/Tvl.VisualStudio.Language.Interfaces/Intellisense/ITvlIntellisenseController.cs
@@ -11,7 +11,6 @@
     using IntPtr = System.IntPtr;
     using IQuickInfoSession = Microsoft.VisualStudio.Language.Intellisense.IQuickInfoSession;
     using ISignatureHelpSession = Microsoft.VisualStudio.Language.Intellisense.ISignatureHelpSession;
-    using ISmartTagSession = Microsoft.VisualStudio.Language.Intellisense.ISmartTagSession;
     using ITextView = Microsoft.VisualStudio.Text.Editor.ITextView;
     using ITrackingPoint = Microsoft.VisualStudio.Text.ITrackingPoint;
     using OLECMDEXECOPT = Microsoft.VisualStudio.OLE.Interop.OLECMDEXECOPT;
@@ -91,11 +90,6 @@
             get;
         }
 
-        ISmartTagSession SmartTagSession
-        {
-            get;
-        }
-
         bool IsCompletionActive
         {
             get;
@@ -117,15 +111,11 @@
 
         void TriggerQuickInfo([NotNull] ITrackingPoint triggerPoint);
 
-        void TriggerSmartTag([NotNull] ITrackingPoint triggerPoint, SmartTagType type, SmartTagState state);
-
         void DismissCompletion();
 
         void DismissQuickInfo();
 
         void DismissSignatureHelp();
-
-        void DismissSmartTag();
 
         void DismissAll();
 

--- a/Tvl.VisualStudio.Language/Intellisense/IntellisenseCommandFilter.cs
+++ b/Tvl.VisualStudio.Language/Intellisense/IntellisenseCommandFilter.cs
@@ -188,11 +188,6 @@
                         }
                         break;
 
-                    case ECMD_SMARTTASKS:
-                        ExpandSmartTagUnderCaret();
-                        handled = true;
-                        break;
-
                     case VSConstants.VSStd2KCmdID.SHOWMEMBERLIST:
                         CompletionHelper.DoTriggerCompletion(Controller, CompletionInfoType.ContextInfo, false, IntellisenseInvocationType.Default);
                         handled = true;
@@ -276,29 +271,6 @@
                 session.Dismiss();
 
             return completionSessions.Count > 0;
-        }
-
-        protected virtual void ExpandSmartTagUnderCaret()
-        {
-            ITextView textView = Controller.TextView;
-            SnapshotPoint? insertionPoint = textView.Caret.Position.Point.GetInsertionPoint(buffer => buffer == textView.TextBuffer);
-            if (!insertionPoint.HasValue)
-                throw new InvalidOperationException();
-
-            ITextSnapshot snapshot = insertionPoint.Value.Snapshot;
-            SnapshotSpan caretSpan = new SnapshotSpan(insertionPoint.Value, 0);
-            IEnumerable<ISmartTagSession> sessions = Controller.Provider.SmartTagBroker.GetSessions(textView);
-            ISmartTagSession session = sessions.FirstOrDefault(i => i.ApplicableToSpan.GetSpan(snapshot).IntersectsWith(caretSpan) && i.Type == SmartTagType.Factoid);
-            List<ISmartTagSession> source = sessions.Where(i => i.Type == SmartTagType.Ephemeral).ToList();
-
-            if (session == null)
-                session = source.FirstOrDefault(i => i.ApplicableToSpan.GetSpan(snapshot).IntersectsWith(caretSpan));
-
-            if (session == null && source.Count == 1)
-                session = source[0];
-
-            if (session != null)
-                session.State = SmartTagState.Expanded;
         }
 
         protected override CommandStatus QueryCommandStatus(ref Guid group, uint id)

--- a/Tvl.VisualStudio.Language/Intellisense/IntellisenseController.cs
+++ b/Tvl.VisualStudio.Language/Intellisense/IntellisenseController.cs
@@ -27,7 +27,6 @@
         private ICompletionSession _completionSession;
         private ISignatureHelpSession _signatureHelpSession;
         private IQuickInfoSession _quickInfoSession;
-        private ISmartTagSession _smartTagSession;
         private readonly Lazy<CompletionInfo> _completionInfo;
         private bool _isProcessingCommand;
 
@@ -177,19 +176,6 @@
             }
         }
 
-        public ISmartTagSession SmartTagSession
-        {
-            get
-            {
-                return _smartTagSession;
-            }
-
-            private set
-            {
-                _smartTagSession = value;
-            }
-        }
-
         public virtual bool IsCompletionActive
         {
             get
@@ -311,19 +297,6 @@
             }
         }
 
-        public virtual void TriggerSmartTag([NotNull] ITrackingPoint triggerPoint, SmartTagType type, SmartTagState state)
-        {
-            Requires.NotNull(triggerPoint, nameof(triggerPoint));
-
-            DismissSmartTag();
-            ISmartTagSession session = Provider.SmartTagBroker.CreateSmartTagSession(TextView, type, triggerPoint, state);
-            if (session != null)
-            {
-                session.Dismissed += HandleSmartTagDismissed;
-                SmartTagSession = session;
-            }
-        }
-
         public virtual void DismissCompletion()
         {
             ICompletionSession session = CompletionSession;
@@ -348,20 +321,11 @@
                 session.Dismiss();
         }
 
-        public virtual void DismissSmartTag()
-        {
-            ISmartTagSession session = SmartTagSession;
-            SmartTagSession = null;
-            if (session != null && !session.IsDismissed)
-                session.Dismiss();
-        }
-
         public virtual void DismissAll()
         {
             DismissCompletion();
             DismissSignatureHelp();
             DismissQuickInfo();
-            DismissSmartTag();
         }
 
         public virtual bool PreprocessCommand(ref Guid commandGroup, uint commandId, OLECMDEXECOPT executionOptions, IntPtr pvaIn, IntPtr pvaOut)
@@ -600,11 +564,6 @@
         protected virtual void HandleQuickInfoDismissed(object sender, EventArgs e)
         {
             QuickInfoSession = null;
-        }
-
-        protected virtual void HandleSmartTagDismissed(object sender, EventArgs e)
-        {
-            SmartTagSession = null;
         }
     }
 }

--- a/Tvl.VisualStudio.Language/Intellisense/IntellisenseControllerProvider.cs
+++ b/Tvl.VisualStudio.Language/Intellisense/IntellisenseControllerProvider.cs
@@ -45,13 +45,6 @@
             private set;
         }
 
-        [Import]
-        public ISmartTagBroker SmartTagBroker
-        {
-            get;
-            private set;
-        }
-
         IIntellisenseController IIntellisenseControllerProvider.TryCreateIntellisenseController(ITextView textView, IList<ITextBuffer> subjectBuffers)
         {
             IntellisenseController controller = TryCreateIntellisenseController(textView, subjectBuffers);


### PR DESCRIPTION
Visual Studio 2019 removed the interfaces from the assemblies altogether, so even if the types were not being used, entire unrelated features ceased to work.

/cc @madskristensen @olegtk these issues are very frustrating when trying to maintain extensions.